### PR TITLE
story/[DT-531]/Adding-labeler-ci-action.

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,10 @@
+feature: ['feature/*', 'feat/*']
+story: ['story/*', 'user-story/*', 'improvement/*', 'enhancement/*']
+bug: ['bug', 'fix/*', 'bugfix/*']
+maintenance: ['maintenance/*', 'refactor/*', 'chore/*']
+research: ['research/*']
+build: ['build/*', 'release/*']
+hotfix: ['hotfix/*']
+# documentation: ['docs/*', 'documentation/']
+# refactor: refactor/*
+# test: ['test/*', 'testing/*']

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -1,0 +1,13 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Testing this from a great article: https://adambohannon.me/using-git-hub-actions-for-automatic-pr-labeling-release-notes-and-version-bumping